### PR TITLE
ZAIUS-7910: details is required

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zaius/app-sdk",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "Zaius App SDK and interfaces",
   "repository": "https://github.com/ZaiusInc/app-sdk",
   "license": "UNLICENSED",

--- a/src/activity-logging/ActivityLogger.ts
+++ b/src/activity-logging/ActivityLogger.ts
@@ -4,34 +4,34 @@ export interface ActivityLogger {
    * @param activity The activity
    * @param title The title
    * @param summary The activity summary
-   * @param [details] The activity details
+   * @param details The activity details
    */
-  info(activity: string, title: string, summary: string, details?: string): void;
+  info(activity: string, title: string, summary: string, details: string): void;
 
   /**
    * Write a sucess message to the activity log.
    * @param activity The activity
    * @param title The title
    * @param summary The activity summary
-   * @param [details] The activity details
+   * @param details The activity details
    */
-  success(activity: string, title: string, summary: string, details?: string): void;
+  success(activity: string, title: string, summary: string, details: string): void;
 
   /**
    * Write a warning message to the activity log.
    * @param activity The activity
    * @param title The title
    * @param summary The activity summary
-   * @param [details] The activity details
+   * @param details The activity details
    */
-  warn(activity: string, title: string, summary: string, details?: string): void;
+  warn(activity: string, title: string, summary: string, details: string): void;
 
   /**
    * Write an error message to the activity log.
    * @param activity The activity
    * @param title The title
    * @param summary The activity summary
-   * @param [details] The activity details
+   * @param details The activity details
    */
-  error(activity: string, title: string, summary: string, details?: string): void;
+  error(activity: string, title: string, summary: string, details: string): void;
 }

--- a/src/activity-logging/activityLog.ts
+++ b/src/activity-logging/activityLog.ts
@@ -14,19 +14,19 @@ export const setActivityLogger = (logger: ActivityLogger) => {
  * Namespace for accessing activity apis
  */
 export const activityLog: ActivityLogger = {
-  info(activity: string, title: string, summary: string, details?: string) {
+  info(activity: string, title: string, summary: string, details: string) {
     activityLogger.info(activity, title, summary, details);
   },
 
-  success(activity: string, title: string, summary: string, details?: string) {
+  success(activity: string, title: string, summary: string, details: string) {
     activityLogger.success(activity, title, summary, details);
   },
 
-  warn(activity: string, title: string, summary: string, details?: string) {
+  warn(activity: string, title: string, summary: string, details: string) {
     activityLogger.warn(activity, title, summary, details);
   },
 
-  error(activity: string, title: string, summary: string, details?: string) {
+  error(activity: string, title: string, summary: string, details: string) {
     activityLogger.error(activity, title, summary, details);
   }
 };


### PR DESCRIPTION
Contrary to what we had before, the `details` field is required by Prism:  

```ruby
  validates :account_id, presence: true
  validates :category,   presence: true
  validates :activity,   presence: true
  validates :status,     presence: true
  validates :details,    presence: true
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zaiusinc/app-sdk/21)
<!-- Reviewable:end -->
