### PR TITLE
OCP-1213: add support for dynamic schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ yalc.lock
 docs/
 .vscode/
 *.iml
+
+jest-results.xml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zaiusinc/app-sdk",
-  "version": "2.1.0-OCP-1137.1",
+  "version": "2.1.0-OCP-1137.2",
   "description": "Optimizely Connect Platform App SDK and interfaces",
   "repository": "https://github.com/ZaiusInc/app-sdk",
   "license": "Apache-2.0",

--- a/src/app/SourceFunction.ts
+++ b/src/app/SourceFunction.ts
@@ -5,7 +5,7 @@ import { Response } from './lib/Response';
 export interface SourceConfiguration {
   dataSyncId: string;
   sourceKey: string;
-  schema: string;
+  schema: string | { entry_point: string };
   webhookUrl?: string;
 }
 

--- a/src/app/SourceSchemaFunction.ts
+++ b/src/app/SourceSchemaFunction.ts
@@ -1,0 +1,15 @@
+import {SourceSchema} from './types';
+
+export interface SourceSchemaFunctionConfig {
+  sourceKey: string;
+}
+
+export abstract class SourceSchemaFunction {
+  protected config: SourceSchemaFunctionConfig;
+
+  public constructor(config: SourceSchemaFunctionConfig) {
+    this.config = config;
+  }
+
+  public abstract getSourcesSchema(): Promise<SourceSchema>;
+}

--- a/src/app/types/AppManifest.schema.json
+++ b/src/app/types/AppManifest.schema.json
@@ -205,7 +205,14 @@
                     "$ref": "#/definitions/AppSourceLifecycle"
                 },
                 "schema": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/AppSourceSchemaFunction"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
                 }
             },
             "required": [
@@ -227,6 +234,18 @@
             "type": "object"
         },
         "AppSourceLifecycle": {
+            "additionalProperties": false,
+            "properties": {
+                "entry_point": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "entry_point"
+            ],
+            "type": "object"
+        },
+        "AppSourceSchemaFunction": {
             "additionalProperties": false,
             "properties": {
                 "entry_point": {

--- a/src/app/types/AppManifest.ts
+++ b/src/app/types/AppManifest.ts
@@ -46,7 +46,7 @@ export interface AppDestination {
 
 export interface AppSource {
   description: string;
-  schema: string;
+  schema: string | AppSourceSchemaFunction;
   function?: AppSourceFunction;
   lifecycle?: AppSourceLifecycle;
 }
@@ -56,6 +56,10 @@ export interface AppSourceLifecycle {
 }
 
 export interface AppSourceFunction {
+  entry_point: string;
+}
+
+export interface AppSourceSchemaFunction {
   entry_point: string;
 }
 

--- a/src/app/validation/tests/validateSource.test.ts
+++ b/src/app/validation/tests/validateSource.test.ts
@@ -1,7 +1,9 @@
 /* eslint-disable max-classes-per-file, @typescript-eslint/no-unsafe-call */
 import { SourceFunction } from '../../SourceFunction';
+import { SourceSchemaFunction } from '../../SourceSchemaFunction';
 import { SourceCreateResponse, SourceDeleteResponse, SourceEnableResponse, SourceLifecycle, SourcePauseResponse, SourceUpdateResponse } from '../../SourceLifecycle';
 import { Response } from '../../lib';
+import { SourceSchema } from '../../types';
 import { validateSources } from '../validateSources';
 
 // Mock fs module
@@ -21,6 +23,30 @@ const existsSyncMock = mockedModule.mocks.existsSyncMock;
 class ValidSourceFunction extends SourceFunction {
   public async perform(): Promise<Response> {
     return new Response();
+  }
+}
+class ValidSourceSchemaFunction extends SourceSchemaFunction {
+  public async getSourcesSchema(): Promise<SourceSchema> {
+    return Promise.resolve({
+      name: 'asset',
+      description: 'Asset Schema for Hub Shakedown',
+      display_name: 'Hub Shakedown Schema',
+      fields: [
+        {
+          name: 'hub_shakedown_name',
+          type: 'string',
+          display_name: 'Hub Shakedown Name',
+          description: 'The name',
+          primary: true,
+        },
+      ],
+    });
+  }
+}
+
+class InvalidSourceSchemaFunction extends Function {
+  public async getSourcesSchema(): Promise<SourceSchema> {
+    return {} as SourceSchema;
   }
 }
 
@@ -116,7 +142,7 @@ describe('validateSources', () => {
       expect(result).toContain('Source is missing the schema property: missingSchema');
     });
 
-    it('should return error when schema is not a string', async () => {
+    it('should return error when schema name is not a string', async () => {
       const runtime: any = getRuntime('invalidSchema', {
         function: {
           entry_point: 'SourceEntry'
@@ -126,7 +152,7 @@ describe('validateSources', () => {
 
       const result = await validateSources(runtime);
 
-      expect(result).toContain('Source schema property must be a string: invalidSchema');
+      expect(result).toContain('Source schema property must be a string or an object: invalidSchema');
     });
 
     it('should return no error when configuration is valid', async () => {
@@ -167,6 +193,55 @@ describe('validateSources', () => {
 
       const result = await validateSources(validRuntime);
       expect(result).toEqual(['File not found for Source schema validSchema']);
+    });
+
+    it('should validate schema entry_point when present', async () => {
+      const validRuntime: any = {
+        manifest: {
+          sources: {
+            validSource: {
+              entry_point: 'validSourceClass',
+              schema: {
+                entry_point: 'ValidSourceSchemaFunction',
+              },
+            },
+          },
+        },
+        getSourceFunctionClass: () => ValidSourceFunction,
+        getSourceLifecycleClass: () => ValidSourceLifecycle,
+        getSourceSchemaFunctionClass: () => ValidSourceSchemaFunction,
+      };
+
+      existsSyncMock.mockReturnValueOnce(true);
+
+      const result = await validateSources(validRuntime);
+      expect(result.length).toEqual(0);
+    });
+
+    it('should return errors if schema entry_point is not extending the correct interface', async () => {
+      const validRuntime: any = {
+        manifest: {
+          sources: {
+            validSource: {
+              entry_point: 'validSourceClass',
+              schema: {
+                entry_point: 'InvalidSourceSchemaFunction',
+              },
+            },
+          },
+        },
+        getSourceFunctionClass: () => ValidSourceFunction,
+        getSourceLifecycleClass: () => ValidSourceLifecycle,
+        getSourceSchemaFunctionClass: () => InvalidSourceSchemaFunction,
+      };
+
+      existsSyncMock.mockReturnValueOnce(true);
+
+      const result = await validateSources(validRuntime);
+      expect(result.length).toEqual(1);
+      expect(result).toContain(
+        'SourceSchemaFunction entry point does not extend App.SourceSchemaFunction: InvalidSourceSchemaFunction',
+      );
     });
   });
 

--- a/src/app/validation/validateSources.ts
+++ b/src/app/validation/validateSources.ts
@@ -1,4 +1,5 @@
 import { SourceFunction } from '../SourceFunction';
+import { SourceSchemaFunction } from '../SourceSchemaFunction';
 import { Runtime } from '../Runtime';
 import * as fs from 'fs';
 import { join } from 'path';
@@ -29,13 +30,33 @@ async function validateSchema(runtime: Runtime, name: string) {
     errors.push(`Source is missing the schema property: ${name}`);
   } else {
     const schema = source.schema;
-    const schemaFilePath = join(runtime.baseDir, 'sources', 'schema', schema);
-    if (typeof (schema) !== 'string') {
-      errors.push(`Source schema property must be a string: ${name}`);
-    } else if (schema.trim() === '') {
-      errors.push(`Source schema property cannot be empty: ${name}`);
-    } else if (!(fs.existsSync(schemaFilePath + '.yml') || fs.existsSync(schemaFilePath + '.yaml'))) {
-      errors.push(`File not found for Source schema ${schema}`);
+    if (typeof schema !== 'object') {
+      const schemaFilePath = join(runtime.baseDir, 'sources', 'schema', schema);
+      if (typeof schema !== 'string') {
+        errors.push(`Source schema property must be a string or an object: ${name}`);
+      } else if (schema.trim() === '') {
+        errors.push(`Source schema property cannot be empty: ${name}`);
+      } else if (!(fs.existsSync(schemaFilePath + '.yml') || fs.existsSync(schemaFilePath + '.yaml'))) {
+        errors.push(`File not found for Source schema ${schema}`);
+      }
+    } else if (schema.entry_point) {
+      let sourceSchemaFunction = null;
+      try {
+        sourceSchemaFunction = await runtime.getSourceSchemaFunctionClass(name);
+      } catch (e: any) {
+        errors.push(`Error loading SourceSchemaFunction entry point ${schema.entry_point}. ${e}`);
+      }
+      if (sourceSchemaFunction) {
+        if (!(sourceSchemaFunction.prototype instanceof SourceSchemaFunction)) {
+          errors.push(
+            'SourceSchemaFunction entry point does not extend App.SourceSchemaFunction: ' + `${schema.entry_point}`,
+          );
+        } else if (typeof (sourceSchemaFunction.prototype as any)['getSourcesSchema'] !== 'function') {
+          errors.push(
+            'SourceSchemaFunction entry point is missing the getSourcesSchema method: ' + `${schema.entry_point}`,
+          );
+        }
+      }
     }
   }
   return errors;


### PR DESCRIPTION
- users will be able to provide schemas dynamically by configuring a Function extending `SourceSchemaFunction` in the `sources` directory, where other functions live.
- they'll be able to configure a Function per source.
- the runtime needs to differentiate when to fetch the static schema or when to fetch the dynamic schema based on the manifest.

Checklist:

- [ ] internal documentation is up-to-date
- [ ] external documentation is up-to-date

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ZaiusInc/app-sdk/154)
<!-- Reviewable:end -->
