### PR TITLE
OCP-1290: add support for dynamic schema for destination apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zaiusinc/app-sdk",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Optimizely Connect Platform App SDK and interfaces",
   "repository": "https://github.com/ZaiusInc/app-sdk",
   "license": "Apache-2.0",

--- a/src/app/DestinationSchemaFunction.ts
+++ b/src/app/DestinationSchemaFunction.ts
@@ -1,0 +1,15 @@
+import {DestinationSchema} from './types';
+
+export interface DestinationSchemaFunctionConfig {
+  destinationKey: string;
+}
+
+export abstract class DestinationSchemaFunction {
+  protected config: DestinationSchemaFunctionConfig;
+
+  public constructor(config: DestinationSchemaFunctionConfig) {
+    this.config = config;
+  }
+
+  public abstract getDestinationsSchema(): Promise<DestinationSchema>;
+}

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -10,6 +10,7 @@ export * from './LiquidExtension';
 export * from './Runtime';
 export * from './types';
 export * from './Destination';
+export * from './DestinationSchemaFunction';
 export * from './SourceFunction';
 export * from './SourceLifecycle';
 export * from './SourceSchemaFunction';

--- a/src/app/types/AppManifest.schema.json
+++ b/src/app/types/AppManifest.schema.json
@@ -64,13 +64,32 @@
                     "type": "string"
                 },
                 "schema": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/AppDestinationSchemaFunction"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
                 }
             },
             "required": [
                 "description",
                 "entry_point",
                 "schema"
+            ],
+            "type": "object"
+        },
+        "AppDestinationSchemaFunction": {
+            "additionalProperties": false,
+            "properties": {
+                "entry_point": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "entry_point"
             ],
             "type": "object"
         },
@@ -121,26 +140,6 @@
                 "cron": {
                     "type": "string"
                 },
-                "description": {
-                    "type": "string"
-                },
-                "entry_point": {
-                    "type": "string"
-                },
-                "parameters": {
-                    "$ref": "#/definitions/ValueHash",
-                    "description": "An object with some restrictions. An interface that follows the ValueHash interface\ncan be safely written to any storage option."
-                }
-            },
-            "required": [
-                "description",
-                "entry_point"
-            ],
-            "type": "object"
-        },
-        "AppSourceJob": {
-            "additionalProperties": false,
-            "properties": {
                 "description": {
                     "type": "string"
                 },
@@ -222,7 +221,10 @@
                     "$ref": "#/definitions/AppSourceFunction"
                 },
                 "jobs": {
-                    "$ref": "#/definitions/AppSourceJob"
+                    "additionalProperties": {
+                        "$ref": "#/definitions/AppSourceJob"
+                    },
+                    "type": "object"
                 },
                 "lifecycle": {
                     "$ref": "#/definitions/AppSourceLifecycle"
@@ -252,6 +254,26 @@
                 }
             },
             "required": [
+                "entry_point"
+            ],
+            "type": "object"
+        },
+        "AppSourceJob": {
+            "additionalProperties": false,
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "entry_point": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "$ref": "#/definitions/ValueHash",
+                    "description": "An object with some restrictions. An interface that follows the ValueHash interface\ncan be safely written to any storage option."
+                }
+            },
+            "required": [
+                "description",
                 "entry_point"
             ],
             "type": "object"

--- a/src/app/types/AppManifest.ts
+++ b/src/app/types/AppManifest.ts
@@ -46,7 +46,7 @@ export interface AppLiquidExtension {
 
 export interface AppDestination {
   entry_point: string;
-  schema: string;
+  schema: string | AppDestinationSchemaFunction;
   description: string;
 }
 
@@ -69,6 +69,10 @@ export interface AppSourceFunction {
 }
 
 export interface AppSourceSchemaFunction {
+  entry_point: string;
+}
+
+export interface AppDestinationSchemaFunction {
   entry_point: string;
 }
 

--- a/src/app/validation/tests/validateDestination.test.ts
+++ b/src/app/validation/tests/validateDestination.test.ts
@@ -1,20 +1,60 @@
-import { validateDestinations } from '../validateDestinations';
-import { Destination, GetDestinationSchemaResult } from '../../Destination';
+/* eslint-disable max-classes-per-file */
+
+import {validateDestinations} from '../validateDestinations';
+import {Destination, GetDestinationSchemaResult} from '../../Destination';
 import fs from 'fs';
+import {DestinationSchema} from '../..';
+import {DestinationSchemaFunction} from '../../DestinationSchemaFunction';
 
 class ValidDestination extends Destination<any> {
   public getDestinationSchema(): Promise<GetDestinationSchemaResult> {
     throw new Error('Method not implemented.');
   }
   public async ready() {
-    return { ready: true };
+    return {ready: true};
   }
   public async deliver(batch: any) {
-    return { success: !batch };
+    return {success: !batch};
   }
 }
 
-jest.spyOn(fs, 'existsSync');
+class ValidDestinationSchemaFunction extends DestinationSchemaFunction {
+  public async getDestinationsSchema(): Promise<DestinationSchema> {
+    return Promise.resolve({
+      name: 'asset',
+      description: 'Asset Schema for Hub Shakedown',
+      display_name: 'Hub Shakedown Schema',
+      fields: [
+        {
+          name: 'hub_shakedown_name',
+          type: 'string',
+          display_name: 'Hub Shakedown Name',
+          description: 'The name',
+          primary: true,
+        },
+      ],
+    });
+  }
+}
+
+class InvalidDestinationSchemaFunction extends Function {
+  public async getDestinationsSchema(): Promise<DestinationSchema> {
+    return {} as DestinationSchema;
+  }
+}
+
+jest.mock('fs', () => {
+  const originalExistsSyncMock = jest.fn();
+  return {
+    existsSync: originalExistsSyncMock,
+    mocks: {
+      existsSyncMock: originalExistsSyncMock,
+    },
+  };
+});
+
+const mockedModule = jest.requireMock('fs');
+const existsSyncMock: jest.Mock = mockedModule.mocks.existsSyncMock;
 
 jest.mock('path', () => ({
   ...jest.requireActual('path'),
@@ -22,55 +62,59 @@ jest.mock('path', () => ({
 }));
 
 describe('validateDestination', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   const invalidRuntime: any = {
     manifest: {
       destinations: {
-        'validDestination': {
+        validDestination: {
           entry_point: 'validDestinationClass',
-          schema: 'validSchema'
+          schema: 'validSchema',
         },
-        'missingSchema': {
-          entry_point: 'missingSchemaClass'
+        missingSchema: {
+          entry_point: 'missingSchemaClass',
         },
-        'invalidSchema': {
+        invalidSchema: {
           entry_point: 'invalidSchemaClass',
-          schema: 123
+          schema: 123,
         },
-      }
+      },
     },
-    getDestinationClass: jest.fn()
+    getDestinationClass: jest.fn(),
   };
 
   it('should return error when destination cannot be loaded', async () => {
-    const getDestinationsClass = jest.spyOn(invalidRuntime, 'getDestinationClass')
+    const getDestinationsClass = jest
+      .spyOn(invalidRuntime, 'getDestinationClass')
       .mockRejectedValue(new Error('not found'));
     const result = await validateDestinations(invalidRuntime);
     getDestinationsClass.mockRestore();
     expect(result).toContain('Error loading entry point validDestination. Error: not found');
   });
 
-
   it('should return error when schema is missing', async () => {
     const result = await validateDestinations(invalidRuntime);
     expect(result).toContain('Destination is missing the schema property: missingSchema');
   });
 
-  it('should return error when schema is not a string', async () => {
+  it('should return error when schema is not a string or an object', async () => {
     const result = await validateDestinations(invalidRuntime);
-    expect(result).toContain('Destination schema property must be a string: invalidSchema');
+    expect(result).toContain('Destination schema property must be a string or an object: invalidSchema');
   });
 
   it('should return no error when configuration is valid', async () => {
     const validRuntime: any = {
       manifest: {
         destinations: {
-          'validDestination': {
+          validDestination: {
             entry_point: 'validDestinationClass',
-            schema: 'validSchema'
-          }
-        }
+            schema: 'validSchema',
+          },
+        },
       },
-      getDestinationClass: () => ValidDestination
+      getDestinationClass: () => ValidDestination,
     };
 
     jest.spyOn(fs, 'existsSync').mockImplementationOnce(() => true);
@@ -82,17 +126,61 @@ describe('validateDestination', () => {
     const validRuntime: any = {
       manifest: {
         destinations: {
-          'validDestination': {
+          validDestination: {
             entry_point: 'validDestinationClass',
-            schema: 'validSchema'
-          }
-        }
+            schema: 'validSchema',
+          },
+        },
       },
-      getDestinationClass: () => ValidDestination
+      getDestinationClass: () => ValidDestination,
     };
 
-    jest.spyOn(fs, 'existsSync').mockImplementationOnce(() => false);
+    existsSyncMock.mockReturnValueOnce(false);
     const result = await validateDestinations(validRuntime);
     expect(result).toEqual(['File not found for Destination schema validSchema']);
+  });
+
+  it('should validate schema entry_point when present', async () => {
+    const validRuntime: any = {
+      manifest: {
+        destinations: {
+          validDestination: {
+            entry_point: 'validDestinationClass',
+            schema: {
+              entry_point: 'ValidDestinationSchemaFunction',
+            },
+          },
+        },
+      },
+      getDestinationClass: () => ValidDestination,
+      getDestinationSchemaFunctionClass: () => ValidDestinationSchemaFunction,
+    };
+
+    const result = await validateDestinations(validRuntime);
+    expect(result.length).toEqual(0);
+  });
+
+  it('should return errors if schema entry_point is not extending the correct interface', async () => {
+    const runtime: any = {
+      manifest: {
+        destinations: {
+          validDestination: {
+            entry_point: 'validDestinationClass',
+            schema: {
+              entry_point: 'InvalidDestinationSchemaFunction',
+            },
+          },
+        },
+      },
+      getDestinationClass: () => ValidDestination,
+      getDestinationSchemaFunctionClass: () => InvalidDestinationSchemaFunction,
+    };
+
+    const result = await validateDestinations(runtime);
+    expect(result.length).toEqual(1);
+    expect(result).toContain(
+      'DestinationSchemaFunction entry point does not extend ' +
+        'App.DestinationSchemaFunction: InvalidDestinationSchemaFunction',
+    );
   });
 });


### PR DESCRIPTION
### What 

- users will be able to provide schemas dynamically by configuring a Function extending `DestinationSchemaFunction` in the `destinations` directory, where other functions live.
- they'll be able to configure a Function per destination.
- the runtime needs to differentiate when to fetch the static schema or when to fetch the dynamic schema based on the manifest.

### How to test

- The [hub_shakedown](https://staging.zaius.com/app?scope=1838#/directory?pathname=%2Fapp%2Fhub_shakedown&search=%3Ftab%3Dsettings&hash=) app in staging has these changes applied in it.
- You can create a new data_sync with source (bar_source) and destinations (foo_export_dynamic) from hub_shakedown.
- Try out changing the schemas from settings and see if you get the changes in the UI or not in data_syncs...
- e.g.
  
<img width="1233" height="672" alt="image" src="https://github.com/user-attachments/assets/d3a19dc6-1dc9-4dff-a739-7af2bbd3994f" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ZaiusInc/app-sdk/156)
<!-- Reviewable:end -->
