### PR TITLE
OCP-1344: Allow integer types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zaiusinc/app-sdk",
-  "version": "2.2.3-beta.1",
+  "version": "2.2.3-beta.2",
   "description": "Optimizely Connect Platform App SDK and interfaces",
   "repository": "https://github.com/ZaiusInc/app-sdk",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zaiusinc/app-sdk",
-  "version": "2.2.3-beta.2",
+  "version": "2.2.3-beta.3",
   "description": "Optimizely Connect Platform App SDK and interfaces",
   "repository": "https://github.com/ZaiusInc/app-sdk",
   "license": "Apache-2.0",

--- a/src/app/validation/validateDestinationsSchema.ts
+++ b/src/app/validation/validateDestinationsSchema.ts
@@ -113,7 +113,7 @@ class DestinationSchemaValidator {
   private validateCustomTypeReference(field: DestinationSchemaField, pathPrefix: string) {
     const customTypes = (this.destinationsSchema.custom_types || []).map((ct: DestinationSchemaCustomType) => ct.name);
     const customTypeMatch = field.type.match(/^\w+$/);
-    if (customTypeMatch && !['boolean', 'float', 'integer', 'long', 'string'].includes(field.type)) {
+    if (customTypeMatch && !['boolean', 'float', 'int', 'integer', 'long', 'string'].includes(field.type)) {
       if (!customTypes.includes(field.type)) {
         this.errors.push(
           `Invalid ${this.file}: ${pathPrefix}.type '${field.type}' does not match any custom_types name`
@@ -124,7 +124,7 @@ class DestinationSchemaValidator {
     const arrayTypeMatch = field.type.match(/^\[(\w+)\]$/);
     if (arrayTypeMatch) {
       const arrayType = arrayTypeMatch[1];
-      if (!['boolean', 'float', 'integer', 'long', 'string'].includes(arrayType) && !customTypes.includes(arrayType)) {
+      if (!['boolean', 'float', 'int', 'integer', 'long', 'string'].includes(arrayType) && !customTypes.includes(arrayType)) {
         this.errors.push(
           `Invalid ${this.file}: ${pathPrefix}.type '${field.type}' array type does not match any custom_types name`
         );

--- a/src/app/validation/validateDestinationsSchema.ts
+++ b/src/app/validation/validateDestinationsSchema.ts
@@ -114,7 +114,7 @@ class DestinationSchemaValidator {
     const customTypes = (this.destinationsSchema.custom_types || []).map((ct: DestinationSchemaCustomType) => ct.name);
     const customTypeMatch = field.type.match(/^\w+$/);
     if (customTypeMatch &&
-      !['boolean', 'float', 'int', 'integer', 'long', 'string'].includes(field.type)) {
+        !['boolean', 'float', 'int', 'integer', 'long', 'string'].includes(field.type)) {
       if (!customTypes.includes(field.type)) {
         this.errors.push(
           `Invalid ${this.file}: ${pathPrefix}.type '${field.type}' does not match any custom_types name`
@@ -126,7 +126,7 @@ class DestinationSchemaValidator {
     if (arrayTypeMatch) {
       const arrayType = arrayTypeMatch[1];
       if (!['boolean', 'float', 'int', 'integer', 'long', 'string'].includes(arrayType) &&
-        !customTypes.includes(arrayType)) {
+          !customTypes.includes(arrayType)) {
         this.errors.push(
           `Invalid ${this.file}: ${pathPrefix}.type '${field.type}' array type does not match any custom_types name`
         );

--- a/src/app/validation/validateDestinationsSchema.ts
+++ b/src/app/validation/validateDestinationsSchema.ts
@@ -113,7 +113,7 @@ class DestinationSchemaValidator {
   private validateCustomTypeReference(field: DestinationSchemaField, pathPrefix: string) {
     const customTypes = (this.destinationsSchema.custom_types || []).map((ct: DestinationSchemaCustomType) => ct.name);
     const customTypeMatch = field.type.match(/^\w+$/);
-    if (customTypeMatch && !['boolean', 'float', 'int', 'long', 'string'].includes(field.type)) {
+    if (customTypeMatch && !['boolean', 'float', 'integer', 'long', 'string'].includes(field.type)) {
       if (!customTypes.includes(field.type)) {
         this.errors.push(
           `Invalid ${this.file}: ${pathPrefix}.type '${field.type}' does not match any custom_types name`
@@ -124,7 +124,7 @@ class DestinationSchemaValidator {
     const arrayTypeMatch = field.type.match(/^\[(\w+)\]$/);
     if (arrayTypeMatch) {
       const arrayType = arrayTypeMatch[1];
-      if (!['boolean', 'float', 'int', 'long', 'string'].includes(arrayType) && !customTypes.includes(arrayType)) {
+      if (!['boolean', 'float', 'integer', 'long', 'string'].includes(arrayType) && !customTypes.includes(arrayType)) {
         this.errors.push(
           `Invalid ${this.file}: ${pathPrefix}.type '${field.type}' array type does not match any custom_types name`
         );

--- a/src/app/validation/validateDestinationsSchema.ts
+++ b/src/app/validation/validateDestinationsSchema.ts
@@ -113,7 +113,8 @@ class DestinationSchemaValidator {
   private validateCustomTypeReference(field: DestinationSchemaField, pathPrefix: string) {
     const customTypes = (this.destinationsSchema.custom_types || []).map((ct: DestinationSchemaCustomType) => ct.name);
     const customTypeMatch = field.type.match(/^\w+$/);
-    if (customTypeMatch && !['boolean', 'float', 'int', 'integer', 'long', 'string'].includes(field.type)) {
+    if (customTypeMatch &&
+      !['boolean', 'float', 'int', 'integer', 'long', 'string'].includes(field.type)) {
       if (!customTypes.includes(field.type)) {
         this.errors.push(
           `Invalid ${this.file}: ${pathPrefix}.type '${field.type}' does not match any custom_types name`
@@ -124,7 +125,8 @@ class DestinationSchemaValidator {
     const arrayTypeMatch = field.type.match(/^\[(\w+)\]$/);
     if (arrayTypeMatch) {
       const arrayType = arrayTypeMatch[1];
-      if (!['boolean', 'float', 'int', 'integer', 'long', 'string'].includes(arrayType) && !customTypes.includes(arrayType)) {
+      if (!['boolean', 'float', 'int', 'integer', 'long', 'string'].includes(arrayType) &&
+        !customTypes.includes(arrayType)) {
         this.errors.push(
           `Invalid ${this.file}: ${pathPrefix}.type '${field.type}' array type does not match any custom_types name`
         );

--- a/src/app/validation/validateSourcesSchema.ts
+++ b/src/app/validation/validateSourcesSchema.ts
@@ -113,7 +113,7 @@ class SourceSchemaValidator {
   private validateCustomTypeReference(field: SourceSchemaField, pathPrefix: string) {
     const customTypes = (this.sourcesSchema.custom_types || []).map((ct: SourceSchemaCustomType) => ct.name);
     const customTypeMatch = field.type.match(/^\w+$/);
-    if (customTypeMatch && !['boolean', 'float', 'int', 'long', 'string'].includes(field.type)) {
+    if (customTypeMatch && !['boolean', 'float', 'int', 'integer', 'long', 'string'].includes(field.type)) {
       if (!customTypes.includes(field.type)) {
         this.errors.push(
           `Invalid ${this.file}: ${pathPrefix}.type '${field.type}' does not match any custom_types name`
@@ -124,7 +124,7 @@ class SourceSchemaValidator {
     const arrayTypeMatch = field.type.match(/^\[(\w+)\]$/);
     if (arrayTypeMatch) {
       const arrayType = arrayTypeMatch[1];
-      if (!['boolean', 'float', 'int', 'long', 'string'].includes(arrayType) && !customTypes.includes(arrayType)) {
+      if (!['boolean', 'float', 'int', 'integer', 'long', 'string'].includes(arrayType) && !customTypes.includes(arrayType)) {
         this.errors.push(
           `Invalid ${this.file}: ${pathPrefix}.type '${field.type}' array type does not match any custom_types name`
         );

--- a/src/app/validation/validateSourcesSchema.ts
+++ b/src/app/validation/validateSourcesSchema.ts
@@ -124,7 +124,8 @@ class SourceSchemaValidator {
     const arrayTypeMatch = field.type.match(/^\[(\w+)\]$/);
     if (arrayTypeMatch) {
       const arrayType = arrayTypeMatch[1];
-      if (!['boolean', 'float', 'int', 'integer', 'long', 'string'].includes(arrayType) && !customTypes.includes(arrayType)) {
+      if (!['boolean', 'float', 'int', 'integer', 'long', 'string'].includes(arrayType) &&
+         !customTypes.includes(arrayType)) {
         this.errors.push(
           `Invalid ${this.file}: ${pathPrefix}.type '${field.type}' array type does not match any custom_types name`
         );


### PR DESCRIPTION
Currently I am unable to validate my app if the type is set to integer:

```
Invalid destinations/schema/destination_primitives.yml: fields[0].type 'integer' does not match any custom_types name
```

Checklist:

- [ ] internal documentation is up-to-date
- [ ] external documentation is up-to-date

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ZaiusInc/app-sdk/162)
<!-- Reviewable:end -->
