### PR TITLE
OCP-1680: validate api for the app-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zaiusinc/app-sdk",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Optimizely Connect Platform App SDK and interfaces",
   "repository": "https://github.com/ZaiusInc/app-sdk",
   "license": "Apache-2.0",
@@ -18,6 +18,9 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "ocp-app-sdk": "dist/cli.js"
+  },
   "directories": {},
   "scripts": {
     "build": "yarn update-schema && tsc",
@@ -34,6 +37,7 @@
   "dependencies": {
     "@zaiusinc/app-forms-schema": "^2.0.0",
     "ajv": "^8.17.1",
+    "chalk": "^4.1.2",
     "cron-expression-validator": "^1.0.20",
     "csv-parser": "^3.2.0",
     "deep-freeze": "^0.0.1",
@@ -43,7 +47,9 @@
     "jsonpath": "^1.1.1",
     "object-hash": "^3.0.0",
     "remark": "^13.0.0",
-    "remark-validate-links": "^10.0.4"
+    "remark-validate-links": "^10.0.4",
+    "to-vfile": "^6.1.0",
+    "vfile": "^4.2.1"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -14,3 +14,4 @@ export * from './DestinationSchemaFunction';
 export * from './SourceFunction';
 export * from './SourceLifecycle';
 export * from './SourceSchemaFunction';
+export * from './validation';

--- a/src/app/validation/index.ts
+++ b/src/app/validation/index.ts
@@ -1,0 +1,95 @@
+import chalk from 'chalk';
+import * as path from 'path';
+
+import {Runtime} from '../Runtime';
+import {validateApp} from './validateApp';
+
+export {validateApp} from './validateApp';
+
+/**
+ * Options for running app validation.
+ */
+export interface RunValidationOptions {
+  /**
+   * The base directory containing the app. Defaults to process.cwd().
+   */
+  baseDir?: string;
+
+  /**
+   * The directory containing the built app relative to baseDir. Defaults to 'dist'.
+   */
+  distDir?: string;
+
+  /**
+   * Whether to suppress console output. Defaults to false.
+   */
+  silent?: boolean;
+
+  /**
+   * Base object names to validate against.
+   */
+  baseObjectNames?: string[];
+}
+
+/**
+ * Result of running app validation.
+ */
+export interface ValidationResult {
+  /**
+   * Whether the validation passed (no errors).
+   */
+  success: boolean;
+
+  /**
+   * Array of error messages. Empty if validation passed.
+   */
+  errors: string[];
+}
+
+/**
+ * Runs validation on an OCP app.
+ *
+ * This is the primary API for validating an app programmatically.
+ *
+ * @example
+ * ```typescript
+ * import { runValidation } from '@zaiusinc/app-sdk';
+ *
+ * const result = await runValidation();
+ * if (!result.success) {
+ *   console.error('Validation failed:', result.errors);
+ *   process.exit(1);
+ * }
+ * ```
+ *
+ * @param options - Configuration options for validation
+ * @returns A promise that resolves to the validation result
+ */
+export async function runValidation(options: RunValidationOptions = {}): Promise<ValidationResult> {
+  const {baseDir = process.cwd(), distDir = 'dist', silent = false, baseObjectNames} = options;
+
+  const appPath = path.resolve(baseDir, distDir);
+
+  try {
+    const runtime = await Runtime.initialize(appPath, true);
+    const errors = await validateApp(runtime, baseObjectNames);
+
+    if (errors.length > 0) {
+      if (!silent) {
+        console.error(chalk.red(`Validation failed:\n${errors.map((e) => ` * ${e}`).join('\n')}`));
+      }
+      return {success: false, errors};
+    } else {
+      if (!silent) {
+        console.log(chalk.green('Looks good to me'));
+      }
+      return {success: true, errors: []};
+    }
+  } catch (e: any) {
+    const errorMessage = `Validation process failed: ${e.message}`;
+    if (!silent) {
+      console.error(chalk.red(errorMessage));
+    }
+    return {success: false, errors: [errorMessage]};
+  }
+}

--- a/src/app/validation/runValidation.ts
+++ b/src/app/validation/runValidation.ts
@@ -1,25 +1,7 @@
-import chalk from 'chalk';
-import * as path from 'path';
+import {runValidation} from './index';
 
-import {Runtime} from '../Runtime';
-import {validateApp} from './validateApp';
-
-Runtime.initialize(path.resolve(process.cwd(), 'dist'), true)
-  .then(async (runtime) => {
-    try {
-      const errors = await validateApp(runtime);
-      if (errors.length > 0) {
-        console.error(chalk.red(`Validation failed:\n${errors.map((e) => ` * ${e}`).join('\n')}`));
-        process.exit(1);
-      } else {
-        console.log(chalk.green('Looks good to me'));
-      }
-    } catch (e: any) {
-      console.error(chalk.red(`Validation process failed: ${e.message}`));
-      process.exit(1);
-    }
-  })
-  .catch((e: any) => {
-    console.error(chalk.red(`Validation process failed: ${e.message}`));
+void runValidation().then((result) => {
+  if (!result.success) {
     process.exit(1);
-  });
+  }
+});

--- a/src/app/validation/tests/runValidation.test.ts
+++ b/src/app/validation/tests/runValidation.test.ts
@@ -1,0 +1,71 @@
+import 'jest';
+
+import {Runtime} from '../../Runtime';
+import {runValidation} from '../index';
+import {validateApp} from '../validateApp';
+
+jest.mock('../../Runtime');
+jest.mock('../validateApp');
+
+describe('runValidation', () => {
+  const mockRuntime = {} as Runtime;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Runtime.initialize as jest.Mock).mockResolvedValue(mockRuntime);
+    (validateApp as jest.Mock).mockResolvedValue([]);
+  });
+
+  it('returns success when validation passes', async () => {
+    const result = await runValidation({silent: true});
+
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('returns failure with errors when validation fails', async () => {
+    (validateApp as jest.Mock).mockResolvedValue(['error 1', 'error 2']);
+
+    const result = await runValidation({silent: true});
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toEqual(['error 1', 'error 2']);
+  });
+
+  it('uses default options when none provided', async () => {
+    await runValidation({silent: true});
+
+    expect(Runtime.initialize).toHaveBeenCalledWith(expect.stringContaining('dist'), true);
+  });
+
+  it('uses custom baseDir and distDir when provided', async () => {
+    await runValidation({baseDir: '/custom/path', distDir: 'build', silent: true});
+
+    expect(Runtime.initialize).toHaveBeenCalledWith('/custom/path/build', true);
+  });
+
+  it('passes baseObjectNames to validateApp', async () => {
+    const baseObjectNames = ['events', 'customers'];
+    await runValidation({baseObjectNames, silent: true});
+
+    expect(validateApp).toHaveBeenCalledWith(mockRuntime, baseObjectNames);
+  });
+
+  it('handles runtime initialization errors', async () => {
+    (Runtime.initialize as jest.Mock).mockRejectedValue(new Error('Failed to initialize'));
+
+    const result = await runValidation({silent: true});
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toEqual(['Validation process failed: Failed to initialize']);
+  });
+
+  it('handles validateApp throwing an error', async () => {
+    (validateApp as jest.Mock).mockRejectedValue(new Error('Validation error'));
+
+    const result = await runValidation({silent: true});
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toEqual(['Validation process failed: Validation error']);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import {runValidation} from './app/validation';
+
+const command = process.argv[2];
+
+async function main(): Promise<void> {
+  switch (command) {
+    case 'validate': {
+      const result = await runValidation();
+      if (!result.success) {
+        process.exit(1);
+      }
+      break;
+    }
+    default:
+      console.error(`Unknown command: ${command}`);
+      console.error('Available commands: validate');
+      process.exit(1);
+  }
+}
+
+void main();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1674,7 +1674,7 @@ caniuse-lite@^1.0.30001688:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001706.tgz#902c3f896f4b2968031c3a546ab2ef8b465a2c8f"
   integrity sha512-3ZczoTApMAZwPKYWmwVbQMFpXBDds3/0VciVoUwPUbldlYyVLmRVuRs/PcUZtHpbLRpzzDvrvnFuREsGt6lUug==
 
-chalk@^4.0.0, chalk@^4.0.2:
+chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -4993,7 +4993,7 @@ to-valid-identifier@^1.0.0:
     "@sindresorhus/base62" "^1.0.0"
     reserved-identifiers "^1.0.0"
 
-to-vfile@^6.0.0:
+to-vfile@^6.0.0, to-vfile@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/to-vfile/-/to-vfile-6.1.0.tgz#5f7a3f65813c2c4e34ee1f7643a5646344627699"
   integrity sha512-BxX8EkCxOAZe+D/ToHdDsJcVI4HqQfmw0tCkp31zf3dNP/XWIAjU4CmeuSwsSoOzOTqHPOL0KUzyZqJplkD0Qw==
@@ -5330,7 +5330,7 @@ vfile-message@^2.0.0:
     "@types/unist" "^2.0.0"
     unist-util-stringify-position "^2.0.0"
 
-vfile@^4.0.0:
+vfile@^4.0.0, vfile@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/vfile/-/vfile-4.2.1.tgz#03f1dce28fc625c625bc6514350fbdb00fa9e624"
   integrity sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==


### PR DESCRIPTION
## What

- New `ocp-app-sdk` cli with `validate` command, so that it can be used in the templates.
- Currently the templates uses `node_modules/@zaiusinc/app-sdk-dist..../runValdiation.js` to validate the app, which works but it's not the proper way to do it. Because it won't work for package managers that doesn't work based on `node_modules` folder (e.g. yarn berry aka 2.x+).
- Also, added `chalk`, `to-vFile` and `vFile` as a direct dependency of the project as it's used in the runValidation api, `yarn berry` at the rescue pointing that out.
