### PR TITLE
OCP-1743: Improve validation error messages with detailed params

### DIFF
--- a/src/app/validation/tests/validateApp.test.ts
+++ b/src/app/validation/tests/validateApp.test.ts
@@ -251,9 +251,27 @@ describe('validateApp', () => {
     const runtime = Runtime.fromJson(JSON.stringify({appManifest: manifest, dirName: '/tmp/foo'}));
 
     expect(await validateApp(runtime)).toEqual([
-      "Invalid app.yml: functions/foo must have required property 'entry_point'",
-      'Invalid app.yml: meta/categories/0 must be equal to one of the allowed values',
-      'Invalid app.yml: runtime must be equal to one of the allowed values'
+      'Invalid app.yml: functions/foo must have required property \'entry_point\' (missingProperty: "entry_point")',
+      'Invalid app.yml: meta/categories/0 must be equal to one of the allowed values ' +
+        '(allowedValues: ["Accounting & Finance","Advertising","Analytics & Reporting","Attribution & Linking",' +
+        '"Audience Sync","CDP / DMP","CRM","Channel","Commerce Platform","Content Management","Customer Experience",' +
+        '"Data Quality & Enrichment","Lead Capture","Loyalty & Rewards","Marketing","Merchandising & Products",' +
+        '"Offers","Opal","Personalization & Content","Point of Sale","Productivity","Reviews & Ratings",' +
+        '"Site & Content Experience","Subscriptions","Surveys & Feedback","Testing & Utilities"])',
+      'Invalid app.yml: runtime must be equal to one of the allowed values ' +
+        '(allowedValues: ["node12","node18","node18_rt","node22"])'
+    ]);
+  });
+
+  it('includes params in error messages', async () => {
+    const manifest = {
+      ...appManifest,
+      functions: {foo: {...appManifest.functions!.foo, invalid_prop: 'test'}}
+    };
+    const runtime = Runtime.fromJson(JSON.stringify({appManifest: manifest, dirName: '/tmp/foo'}));
+
+    expect(await validateApp(runtime)).toEqual([
+      'Invalid app.yml: functions/foo must NOT have additional properties (additionalProperty: "invalid_prop")'
     ]);
   });
 
@@ -284,17 +302,22 @@ describe('validateApp', () => {
     } as any);
 
     expect(await validateApp(runtime)).toEqual([
-      "Invalid destinations/schema/asset.yml: must have required property 'name'",
-      "Invalid destinations/schema/asset.yml: fields/0 must have required property 'display_name'",
+      'Invalid destinations/schema/asset.yml: must have required property \'name\' (missingProperty: "name")',
+      "Invalid destinations/schema/asset.yml: fields/0 must have required property 'display_name' " +
+        '(missingProperty: "display_name")',
       'Invalid destinations/schema/asset.yml: fields/0/type must match pattern ' +
-        '"^(string|integer|boolean|decimal|\\w+|\\[\\w+\\])$"',
-      "Invalid sources/schema/asset.yml: must have required property 'name'",
-      "Invalid sources/schema/asset.yml: fields/0 must have required property 'display_name'",
+        '"^(string|integer|boolean|decimal|\\w+|\\[\\w+\\])$" ' +
+        '(pattern: "^(string|integer|boolean|decimal|\\\\w+|\\\\[\\\\w+\\\\])$")',
+      'Invalid sources/schema/asset.yml: must have required property \'name\' (missingProperty: "name")',
+      "Invalid sources/schema/asset.yml: fields/0 must have required property 'display_name' " +
+        '(missingProperty: "display_name")',
       'Invalid sources/schema/asset.yml: fields/0/type must match pattern ' +
-        '"^(string|integer|boolean|decimal|\\w+|\\[\\w+\\])$"',
-      "Invalid schema/events.yml: must have required property 'name'",
-      "Invalid schema/events.yml: fields/0 must have required property 'description'",
-      'Invalid schema/events.yml: fields/0/type must be equal to one of the allowed values'
+        '"^(string|integer|boolean|decimal|\\w+|\\[\\w+\\])$" ' +
+        '(pattern: "^(string|integer|boolean|decimal|\\\\w+|\\\\[\\\\w+\\\\])$")',
+      'Invalid schema/events.yml: must have required property \'name\' (missingProperty: "name")',
+      'Invalid schema/events.yml: fields/0 must have required property \'description\' (missingProperty: "description")',
+      'Invalid schema/events.yml: fields/0/type must be equal to one of the allowed values ' +
+        '(allowedValues: ["boolean","number","string","timestamp","vector"])'
     ]);
 
     getSchemaObjects.mockRestore();

--- a/src/app/validation/validateApp.ts
+++ b/src/app/validation/validateApp.ts
@@ -87,5 +87,12 @@ export async function validateApp(runtime: Runtime, baseObjectNames?: string[]):
 function formatAjvError(file: string, e: ErrorObject): string {
   const adjustedDataPath =
     e.instancePath.length > 0 ? e.instancePath.substring(1).replace(/\['([^']+)']/, '.$1') + ' ' : '';
-  return `Invalid ${file}: ${adjustedDataPath}${e.message?.replace(/\bshould\b/, 'must') ?? ''}`;
+  let message = e.message?.replace(/\bshould\b/, 'must') ?? '';
+  if (e.params && Object.keys(e.params).length > 0) {
+    const paramsStr = Object.entries(e.params)
+      .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+      .join(', ');
+    message += ` (${paramsStr})`;
+  }
+  return `Invalid ${file}: ${adjustedDataPath}${message}`;
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -25,6 +25,5 @@ export interface OCPRuntime {
 }
 
 declare global {
-  /* eslint-disable no-var */
   var ocpContextStorage: AsyncLocalStorage<OCPContext>;
 }


### PR DESCRIPTION
## Summary

This PR enhances validation error messages in the app-sdk by including all AJV error parameters, making it significantly easier to debug validation failures.

**Part of:** OCP-1689 (parent epic)  
**Jira ticket:** OCP-1743

## Changes

### Core Implementation
- **src/app/validation/validateApp.ts**: Modified `formatAjvError` function to append all error params from AJV to the error message
  - Extracts and formats all params as key-value pairs
  - Appends them in parentheses for easy reading

### Test Updates
- **src/app/validation/tests/validateApp.test.ts**: Updated all test expectations to match the new error format
  - Added new test case `includes params in error messages` to verify additionalProperty errors
  - Updated existing tests with exact error message matching including params

### Minor Cleanup
- **src/types/index.d.ts**: Removed redundant eslint-disable comment

## Benefits

The improved error messages now show all relevant params:
- `additionalProperty: "invalid_prop"` - Shows which property is not allowed
- `missingProperty: "entry_point"` - Shows which required field is missing
- `allowedValues: ["node12","node18",...]` - Shows valid enum values
- `pattern: "^(string|integer|...)"` - Shows expected regex pattern

### Before
```
Invalid app.yml: functions/foo must have required property 'entry_point'
```

### After
```
Invalid app.yml: functions/foo must have required property 'entry_point' (missingProperty: "entry_point")
```

## Test Plan

- [x] Ran existing test suite - all tests updated and passing
- [x] Added new test case for additionalProperty validation
- [x] Verified error messages include all relevant params in different scenarios:
  - Missing required properties
  - Additional/unknown properties
  - Enum validation failures
  - Pattern/regex validation failures

## Related

- Parent epic: OCP-1689
- Jira: https://zaiusinc.atlassian.net/browse/OCP-1743