### PR TITLE
OCP-1778: Introduce accepts parameter for function for cms ui extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zaiusinc/app-sdk",
-  "version": "3.3.3",
+  "version": "3.3.4-OCP-1778.1",
   "description": "Optimizely Connect Platform App SDK and interfaces",
   "repository": "https://github.com/ZaiusInc/app-sdk",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zaiusinc/app-sdk",
-  "version": "3.3.4-OCP-1778.1",
+  "version": "3.3.4-OCP-1778.2",
   "description": "Optimizely Connect Platform App SDK and interfaces",
   "repository": "https://github.com/ZaiusInc/app-sdk",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zaiusinc/app-sdk",
-  "version": "3.3.4-OCP-1778.2",
+  "version": "3.3.4",
   "description": "Optimizely Connect Platform App SDK and interfaces",
   "repository": "https://github.com/ZaiusInc/app-sdk",
   "license": "Apache-2.0",

--- a/src/app/types/AppManifest.schema.json
+++ b/src/app/types/AppManifest.schema.json
@@ -100,6 +100,13 @@
         "AppFunction": {
             "additionalProperties": false,
             "properties": {
+                "accepts": {
+                    "enum": [
+                        "cms_ui_extension",
+                        "http"
+                    ],
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },

--- a/src/app/types/AppManifest.ts
+++ b/src/app/types/AppManifest.ts
@@ -2,12 +2,18 @@ import {ValueHash} from '../../store';
 import {CampaignTargeting} from '../Channel';
 
 // regenerate JSON schema with `yarn run update-schema`
+
+export enum FunctionAccepts {
+  Http = 'http',
+  CmsUiExtension = 'cms_ui_extension'
+}
+
 export interface AppFunction {
   entry_point: string;
   description: string;
   global?: boolean;
   opal_tool?: boolean;
-  accepts?: 'http' | 'cms_ui_extension';
+  accepts?: FunctionAccepts;
   installation_resolution?: {
     type: 'GUID' | 'HEADER' | 'QUERY_PARAM' | 'JSON_BODY_FIELD';
     key: string;

--- a/src/app/types/AppManifest.ts
+++ b/src/app/types/AppManifest.ts
@@ -7,6 +7,7 @@ export interface AppFunction {
   description: string;
   global?: boolean;
   opal_tool?: boolean;
+  accepts?: 'http' | 'cms_ui_extension';
   installation_resolution?: {
     type: 'GUID' | 'HEADER' | 'QUERY_PARAM' | 'JSON_BODY_FIELD';
     key: string;

--- a/src/app/validation/tests/validateFunctions.test.ts
+++ b/src/app/validation/tests/validateFunctions.test.ts
@@ -240,9 +240,7 @@ describe('validateFunctions', () => {
       .spyOn(Runtime.prototype, 'getFunctionClass')
       .mockImplementation((name) => Promise.resolve(name === 'foo' ? ProperFoo : ProperGlobalFoo));
 
-    expect(await validateFunctions(runtime)).toEqual([
-      'Global functions cannot have accepts: cms_ui_extension'
-    ]);
+    expect(await validateFunctions(runtime)).toEqual(['Global functions cannot have accepts: cms_ui_extension']);
     getFunctionClass.mockRestore();
   });
 });

--- a/src/app/validation/tests/validateFunctions.test.ts
+++ b/src/app/validation/tests/validateFunctions.test.ts
@@ -231,4 +231,18 @@ describe('validateFunctions', () => {
     ]);
     getFunctionClass.mockRestore();
   });
+
+  it('detects global functions with accepts: cms_ui_extension', async () => {
+    const runtime = Runtime.fromJson(JSON.stringify({appManifest, dirName: '/tmp/foo'}));
+
+    runtime.manifest.functions!.global_foo.accepts = FunctionAccepts.CmsUiExtension;
+    const getFunctionClass = jest
+      .spyOn(Runtime.prototype, 'getFunctionClass')
+      .mockImplementation((name) => Promise.resolve(name === 'foo' ? ProperFoo : ProperGlobalFoo));
+
+    expect(await validateFunctions(runtime)).toEqual([
+      'Global functions cannot have accepts: cms_ui_extension'
+    ]);
+    getFunctionClass.mockRestore();
+  });
 });

--- a/src/app/validation/tests/validateFunctions.test.ts
+++ b/src/app/validation/tests/validateFunctions.test.ts
@@ -6,7 +6,7 @@ import {Function} from '../../Function';
 import {GlobalFunction} from '../../GlobalFunction';
 import {FunctionClassNotFoundError, Runtime} from '../../Runtime';
 import {Request, Response} from '../../lib';
-import {AppManifest} from '../../types';
+import {AppManifest, FunctionAccepts} from '../../types';
 import {validateFunctions} from '../validateFunctions';
 
 const appManifest = deepFreeze({
@@ -95,7 +95,7 @@ describe('validateFunctions', () => {
 
   it('succeeds with accepts parameter set to http', async () => {
     const runtime = Runtime.fromJson(JSON.stringify({appManifest, dirName: '/tmp/foo'}));
-    runtime.manifest.functions!.foo.accepts = 'http';
+    runtime.manifest.functions!.foo.accepts = FunctionAccepts.Http;
     const getFunctionClass = jest
       .spyOn(Runtime.prototype, 'getFunctionClass')
       .mockImplementation((name) => Promise.resolve(name === 'foo' ? ProperFoo : ProperGlobalFoo));
@@ -109,7 +109,7 @@ describe('validateFunctions', () => {
 
   it('succeeds with accepts parameter set to cms_ui_extension', async () => {
     const runtime = Runtime.fromJson(JSON.stringify({appManifest, dirName: '/tmp/foo'}));
-    runtime.manifest.functions!.foo.accepts = 'cms_ui_extension';
+    runtime.manifest.functions!.foo.accepts = FunctionAccepts.CmsUiExtension;
     const getFunctionClass = jest
       .spyOn(Runtime.prototype, 'getFunctionClass')
       .mockImplementation((name) => Promise.resolve(name === 'foo' ? ProperFoo : ProperGlobalFoo));
@@ -220,7 +220,7 @@ describe('validateFunctions', () => {
   it('detects cms_ui_extension functions with installation_resolution', async () => {
     const runtime = Runtime.fromJson(JSON.stringify({appManifest, dirName: '/tmp/foo'}));
 
-    runtime.manifest.functions!.foo.accepts = 'cms_ui_extension';
+    runtime.manifest.functions!.foo.accepts = FunctionAccepts.CmsUiExtension;
     runtime.manifest.functions!.foo.installation_resolution = {type: 'HEADER', key: 'foo'};
     const getFunctionClass = jest
       .spyOn(Runtime.prototype, 'getFunctionClass')

--- a/src/app/validation/tests/validateFunctions.test.ts
+++ b/src/app/validation/tests/validateFunctions.test.ts
@@ -93,6 +93,34 @@ describe('validateFunctions', () => {
     getFunctionClass.mockRestore();
   });
 
+  it('succeeds with accepts parameter set to http', async () => {
+    const runtime = Runtime.fromJson(JSON.stringify({appManifest, dirName: '/tmp/foo'}));
+    runtime.manifest.functions!.foo.accepts = 'http';
+    const getFunctionClass = jest
+      .spyOn(Runtime.prototype, 'getFunctionClass')
+      .mockImplementation((name) => Promise.resolve(name === 'foo' ? ProperFoo : ProperGlobalFoo));
+
+    const errors = await validateFunctions(runtime);
+
+    expect(errors).toEqual([]);
+
+    getFunctionClass.mockRestore();
+  });
+
+  it('succeeds with accepts parameter set to cms_ui_extension', async () => {
+    const runtime = Runtime.fromJson(JSON.stringify({appManifest, dirName: '/tmp/foo'}));
+    runtime.manifest.functions!.foo.accepts = 'cms_ui_extension';
+    const getFunctionClass = jest
+      .spyOn(Runtime.prototype, 'getFunctionClass')
+      .mockImplementation((name) => Promise.resolve(name === 'foo' ? ProperFoo : ProperGlobalFoo));
+
+    const errors = await validateFunctions(runtime);
+
+    expect(errors).toEqual([]);
+
+    getFunctionClass.mockRestore();
+  });
+
   it('detects missing function entry point', async () => {
     const runtime = Runtime.fromJson(JSON.stringify({appManifest, dirName: '/tmp/foo'}));
     const getFunctionClass = jest
@@ -185,6 +213,21 @@ describe('validateFunctions', () => {
 
     expect(await validateFunctions(runtime)).toEqual([
       'Invalid JSON path expression: Lexical error on line 1. Unrecognized text.\n' + '/test/foo\n' + '^'
+    ]);
+    getFunctionClass.mockRestore();
+  });
+
+  it('detects cms_ui_extension functions with installation_resolution', async () => {
+    const runtime = Runtime.fromJson(JSON.stringify({appManifest, dirName: '/tmp/foo'}));
+
+    runtime.manifest.functions!.foo.accepts = 'cms_ui_extension';
+    runtime.manifest.functions!.foo.installation_resolution = {type: 'HEADER', key: 'foo'};
+    const getFunctionClass = jest
+      .spyOn(Runtime.prototype, 'getFunctionClass')
+      .mockImplementation((name) => Promise.resolve(name === 'foo' ? ProperFoo : ProperGlobalFoo));
+
+    expect(await validateFunctions(runtime)).toEqual([
+      'Functions with accepts: cms_ui_extension cannot define installation_resolution'
     ]);
     getFunctionClass.mockRestore();
   });

--- a/src/app/validation/validateFunctions.ts
+++ b/src/app/validation/validateFunctions.ts
@@ -48,6 +48,10 @@ async function validateInstallationResolution(definition: AppFunction): Promise<
     return ['Global functions cannot define a installation_resolution'];
   }
 
+  if (definition.accepts === 'cms_ui_extension' && definition.installation_resolution) {
+    return ['Functions with accepts: cms_ui_extension cannot define installation_resolution'];
+  }
+
   if (definition.installation_resolution) {
     const {type, key} = definition.installation_resolution;
     if (type === 'JSON_BODY_FIELD') {

--- a/src/app/validation/validateFunctions.ts
+++ b/src/app/validation/validateFunctions.ts
@@ -33,6 +33,9 @@ export async function validateFunctions(runtime: Runtime): Promise<string[]> {
       } else if (typeof fnClass.prototype.perform !== 'function') {
         errors.push(`Function entry point is missing the perform method: ${fnDefinition.entry_point}`);
       }
+      if (fnDefinition.global && fnDefinition.accepts === FunctionAccepts.CmsUiExtension) {
+        errors.push('Global functions cannot have accepts: cms_ui_extension');
+      }
       const installationResolutionErrors = await validateInstallationResolution(fnDefinition);
       if (installationResolutionErrors.length) {
         errors.push(...installationResolutionErrors);

--- a/src/app/validation/validateFunctions.ts
+++ b/src/app/validation/validateFunctions.ts
@@ -3,7 +3,7 @@ import jp from 'jsonpath';
 import {Function} from '../Function';
 import {GlobalFunction} from '../GlobalFunction';
 import {FunctionClassNotFoundError, Runtime} from '../Runtime';
-import {AppFunction} from '../types';
+import {AppFunction, FunctionAccepts} from '../types';
 
 export async function validateFunctions(runtime: Runtime): Promise<string[]> {
   const errors: string[] = [];
@@ -48,7 +48,7 @@ async function validateInstallationResolution(definition: AppFunction): Promise<
     return ['Global functions cannot define a installation_resolution'];
   }
 
-  if (definition.accepts === 'cms_ui_extension' && definition.installation_resolution) {
+  if (definition.accepts === FunctionAccepts.CmsUiExtension && definition.installation_resolution) {
     return ['Functions with accepts: cms_ui_extension cannot define installation_resolution'];
   }
 


### PR DESCRIPTION
Add optional accepts parameter to function definitions in app.yaml                                                                                                                                                    
                                                                                                                                                                                                                        
  Summary                                                                                                                                                                                                               
                                                                                                                                                                                                                      
  This PR adds an optional accepts parameter to the AppFunction interface, allowing developers to specify how a function accepts requests. The parameter can be set to 'http' or 'cms_ui_extension'.

  Changes

  1. Type Definition Updates

  - src/app/types/AppManifest.ts
    - Added accepts?: 'http' | 'cms_ui_extension'; to the AppFunction interface
    - The parameter is optional and accepts only two enum values

  2. JSON Schema Updates

  - src/app/types/AppManifest.schema.json
    - Automatically regenerated to include the new accepts parameter
    - Schema validates that only 'http' or 'cms_ui_extension' values are allowed

  3. Validation Logic

  - src/app/validation/validateFunctions.ts
    - Added validation rule: Functions with accepts: 'cms_ui_extension' cannot define installation_resolution
    - This prevents incompatible configuration combinations