### PR TITLE
OCP-1888: Configure Dependabot to bundle security PRs and bump packag…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    # Schedule only affects version updates (which we disable below);
+    # security updates are event-driven and ignore this. Required by schema.
+    schedule:
+      interval: weekly
+    # Disable version-update PRs; security updates ignore this limit and still run.
+    open-pull-requests-limit: 0
+    versioning-strategy: increase
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
  ## Summary
  - Adds .github/dependabot.yml to customize Dependabot security-update behavior
  - Bundles all security PRs into one grouped PR (instead of one per package)
  - Sets versioning-strategy: increase so package.json constraints are widened, not just yarn.lock
  - Disables version updates (open-pull-requests-limit: 0) — security-only by design

  ## Behavior changes
  - Existing 4 open Dependabot PRs (#182, #183, #184, #187) will be closed and reopened as a single grouped PR on the next Dependabot run
  - Transitive CVEs without an upgrade path remain unfixed (config can't help there)

  ## Test plan
  - [ ] After merge, trigger run via Insights → Dependency graph → Dependabot → "Check for updates"
  - [ ] Verify a single grouped PR appears with both package.json and yarn.lock changes
  - [ ] Confirm CI passes on the grouped PR