### PR TITLE
OCP-2174: App type validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zaiusinc/app-sdk",
-  "version": "3.4.1",
+  "version": "3.4.2-OCP-2174.1",
   "description": "Optimizely Connect Platform App SDK and interfaces",
   "repository": "https://github.com/ZaiusInc/app-sdk",
   "license": "Apache-2.0",

--- a/src/app/validation/tests/validateAppTypeSeparation.test.ts
+++ b/src/app/validation/tests/validateAppTypeSeparation.test.ts
@@ -1,0 +1,98 @@
+import 'jest';
+
+import {Runtime} from '../../Runtime';
+import {AppManifest} from '../../types';
+import {validateAppTypeSeparation} from '../validateApp';
+
+const baseManifest: AppManifest = {
+  meta: {
+    app_id: 'my_app',
+    display_name: 'My App',
+    version: '1.0.0',
+    vendor: 'zaius',
+    support_url: 'https://zaius.com',
+    summary: 'This is an interesting app',
+    contact_email: 'support@zaius.com',
+    categories: ['Commerce Platform'],
+    availability: ['all']
+  },
+  runtime: 'node18',
+  environment: ['APP_ENV_FOO'],
+  functions: {
+    foo: {entry_point: 'Foo', description: 'gets foo'}
+  }
+};
+
+const uiExtensions = {sidebar: [{name: 'a', entry_point: 'A', display_name: 'A'}]};
+
+function buildRuntime(manifest: Record<string, unknown>): Runtime {
+  return Runtime.fromJson(JSON.stringify({appManifest: manifest, dirName: '/tmp/foo'}));
+}
+
+describe('validateAppTypeSeparation', () => {
+  it('returns no errors for a manifest with no ui_extensions', () => {
+    const runtime = buildRuntime({...baseManifest, sources: {foo: {}}, destinations: {bar: {}}});
+    expect(validateAppTypeSeparation(runtime)).toEqual([]);
+  });
+
+  it('returns no errors for a manifest with ui_extensions and no conflicting features', () => {
+    const runtime = buildRuntime({...baseManifest, ui_extensions: uiExtensions});
+    expect(validateAppTypeSeparation(runtime)).toEqual([]);
+  });
+
+  it('rejects ui_extensions combined with sources', () => {
+    const runtime = buildRuntime({
+      ...baseManifest,
+      sources: {foo_source: {description: 'foo', schema: 'asset', function: {entry_point: 'FooSource'}}},
+      ui_extensions: uiExtensions
+    });
+    expect(validateAppTypeSeparation(runtime)).toContain(
+      'Invalid app.yml: ui_extensions cannot be combined with sources'
+    );
+  });
+
+  it('rejects ui_extensions combined with destinations', () => {
+    const runtime = buildRuntime({
+      ...baseManifest,
+      destinations: {foo_dest: {entry_point: 'FooDest', description: 'foo', schema: 'asset'}},
+      ui_extensions: uiExtensions
+    });
+    expect(validateAppTypeSeparation(runtime)).toContain(
+      'Invalid app.yml: ui_extensions cannot be combined with destinations'
+    );
+  });
+
+  it('rejects ui_extensions combined with OPAL tool functions', () => {
+    const runtime = buildRuntime({
+      ...baseManifest,
+      functions: {opal_fn: {entry_point: 'OpalFn', description: 'opal', opal_tool: true}},
+      ui_extensions: uiExtensions
+    });
+    expect(validateAppTypeSeparation(runtime)).toContain(
+      'Invalid app.yml: ui_extensions cannot be combined with opal_tool functions'
+    );
+  });
+
+  it('returns all applicable errors when multiple conflicts exist', () => {
+    const runtime = buildRuntime({
+      ...baseManifest,
+      sources: {foo_source: {}},
+      destinations: {foo_dest: {}},
+      functions: {opal_fn: {entry_point: 'OpalFn', description: 'opal', opal_tool: true}},
+      ui_extensions: uiExtensions
+    });
+    const errors = validateAppTypeSeparation(runtime);
+    expect(errors).toContain('Invalid app.yml: ui_extensions cannot be combined with sources');
+    expect(errors).toContain('Invalid app.yml: ui_extensions cannot be combined with destinations');
+    expect(errors).toContain('Invalid app.yml: ui_extensions cannot be combined with opal_tool functions');
+  });
+
+  it('allows non-OPAL functions alongside ui_extensions', () => {
+    const runtime = buildRuntime({
+      ...baseManifest,
+      functions: {regular_fn: {entry_point: 'Fn', description: 'fn', opal_tool: false}},
+      ui_extensions: uiExtensions
+    });
+    expect(validateAppTypeSeparation(runtime)).toEqual([]);
+  });
+});

--- a/src/app/validation/validateApp.ts
+++ b/src/app/validation/validateApp.ts
@@ -47,7 +47,8 @@ export async function validateApp(runtime: Runtime, baseObjectNames?: string[]):
       .concat(await validateLifecycle(runtime))
       .concat(await validateChannel(runtime))
       .concat(await validateAssets(runtime))
-      .concat(validateOutboundDomains(runtime));
+      .concat(validateOutboundDomains(runtime))
+      .concat(validateAppTypeSeparation(runtime));
   }
 
   if (runtime.manifest.destinations) {
@@ -85,6 +86,29 @@ export async function validateApp(runtime: Runtime, baseObjectNames?: string[]):
   }
 
   errors = errors.concat(await runPluginValidators(runtime, plugins));
+
+  return errors;
+}
+
+export function validateAppTypeSeparation(runtime: Runtime): string[] {
+  const errors: string[] = [];
+  const manifest = runtime.manifest as Record<string, unknown>;
+  const uiExtensions = manifest['ui_extensions'];
+  const hasUiExtensions =
+    uiExtensions != null && typeof uiExtensions === 'object' && Object.keys(uiExtensions).length > 0;
+
+  if (hasUiExtensions) {
+    if (runtime.manifest.sources && Object.keys(runtime.manifest.sources).length > 0) {
+      errors.push('Invalid app.yml: ui_extensions cannot be combined with sources');
+    }
+    if (runtime.manifest.destinations && Object.keys(runtime.manifest.destinations).length > 0) {
+      errors.push('Invalid app.yml: ui_extensions cannot be combined with destinations');
+    }
+    const hasOpalTools = Object.values(runtime.manifest.functions ?? {}).some((fn) => fn.opal_tool === true);
+    if (hasOpalTools) {
+      errors.push('Invalid app.yml: ui_extensions cannot be combined with opal_tool functions');
+    }
+  }
 
   return errors;
 }


### PR DESCRIPTION
 Adds a validation rule to reject app manifests that declare ui_extensions alongside data sync or OPAL features. Part of the CMS UI Extension app type classification work (OCP-2160).

  Changes

  - New validateAppTypeSeparation validation in validateApp.ts — runs after all existing per-section validators and produces Invalid app.yml: errors consistent with the existing error format
  - Rejects the following combinations when ui_extensions is declared:
    - sources (data sync sources)
    - destinations (data sync destinations)
    - Functions with opal_tool: true