### PR TITLE
OCP-2193: Deploy an app to a preview track

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zaiusinc/app-sdk",
-  "version": "3.4.1",
+  "version": "3.5.0-beta.1",
   "description": "Optimizely Connect Platform App SDK and interfaces",
   "repository": "https://github.com/ZaiusInc/app-sdk",
   "license": "Apache-2.0",

--- a/src/app/Runtime.ts
+++ b/src/app/Runtime.ts
@@ -69,6 +69,11 @@ export class Runtime {
     return this.appManifest;
   }
 
+  // Running version: injected APP_VERSION (preview sha or semver), else manifest meta.version.
+  public get version(): string | undefined {
+    return process.env.APP_VERSION ?? this.appManifest?.meta?.version;
+  }
+
   public get baseDir(): string {
     return this.dirName;
   }

--- a/src/app/types/AppManifest.schema.json
+++ b/src/app/types/AppManifest.schema.json
@@ -657,8 +657,7 @@
                 "display_name",
                 "summary",
                 "support_url",
-                "vendor",
-                "version"
+                "vendor"
             ],
             "type": "object"
         },

--- a/src/app/types/AppManifest.ts
+++ b/src/app/types/AppManifest.ts
@@ -190,7 +190,7 @@ export interface AppManifest {
   meta: {
     app_id: string;
     display_name: string;
-    version: string;
+    version?: string;
     vendor: string;
     support_url: string;
     summary: string;

--- a/src/app/validation/tests/validateMeta.test.ts
+++ b/src/app/validation/tests/validateMeta.test.ts
@@ -66,7 +66,7 @@ describe('validateMeta', () => {
     expect(await validateMeta(runtime)).toEqual(['Invalid app.yml: meta.display_name must not be blank']);
   });
 
-  it('detects invalid version', async () => {
+  it('detects invalid version when provided', async () => {
     const manifest = {...appManifest, meta: {...appManifest.meta, version: '1.3'}};
     const runtime = Runtime.fromJson(JSON.stringify({appManifest: manifest, dirName: '/tmp/foo'}));
 
@@ -74,6 +74,15 @@ describe('validateMeta', () => {
       'Invalid app.yml: meta.version must be a semantic version number, optionally with -dev/-beta (and increment) ' +
         'or -private (/^\\d+\\.\\d+\\.\\d+(-(((dev|beta)(\\.\\d+)?)|private))?$/)'
     ]);
+  });
+
+  it('accepts a missing version', async () => {
+    const meta = {...appManifest.meta};
+    delete (meta as {version?: string}).version;
+    const manifest = {...appManifest, meta};
+    const runtime = Runtime.fromJson(JSON.stringify({appManifest: manifest, dirName: '/tmp/foo'}));
+
+    expect(await validateMeta(runtime)).toEqual([]);
   });
 
   it('detects invalid vendor', async () => {

--- a/src/app/validation/validateMeta.ts
+++ b/src/app/validation/validateMeta.ts
@@ -17,7 +17,8 @@ export async function validateMeta(runtime: Runtime): Promise<string[]> {
         `and be between 3 and 32 characters long (${APP_ID_FORMAT.toString()})`
     );
   }
-  if (!version.match(VERSION_FORMAT)) {
+  // meta.version is optional (deployed version wins), but when provided (e.g. ocp app prepare) it must be valid semver.
+  if (version && !version.match(VERSION_FORMAT)) {
     errors.push(
       'Invalid app.yml: meta.version must be a semantic version number, optionally with -dev/-beta (and increment) ' +
         `or -private (${VERSION_FORMAT.toString()})`


### PR DESCRIPTION
Part of the app development lifecycle redesign (preview tracks). Under the new
  model the deployed version is assigned by the platform — a preview-track content
  hash or a semver — so `meta.version` in `app.yml` is no longer required to deploy.
  This makes the SDK treat `meta.version` as optional and lets a running app read
  its actual deployed version at runtime, while keeping the strict semver check for
  the paths that still set a version.

  - **`Runtime.version`** — new getter returning the injected `APP_VERSION` (preview
    sha or semver) when present, falling back to `app.yml` `meta.version`.
  - **`meta.version` is now optional** — removed from the manifest schema's `required`
    set and made optional in the `AppManifest` TypeScript type.
  - **Validation** — `validateMeta` allows a missing `meta.version`, but when a version
    *is* provided it must still be valid semver (a bad value fails validation, as
    before), preserving the `ocp app prepare` semver path.

  ### Behavior change (non-breaking)
  An app with no `meta.version` now passes validation instead of failing. A provided
  version is validated exactly as before. Apps that already set a valid semver are
  unaffected.

  ### How to test
  - `yarn test` — updated specs cover `accepts a missing version` and `detects invalid version when provided`.
  - With `APP_VERSION` set, `Runtime.version` returns it; unset, it falls back to `meta.version`.